### PR TITLE
Bug: cache dir from environment is of type string

### DIFF
--- a/src/cltcache/cltcache.py
+++ b/src/cltcache/cltcache.py
@@ -134,8 +134,8 @@ def compute_cache_key(clang_tidy_call, config):
 
 
 def init_cltcache():
-    cltcache_path = os.environ.get(
-        "CLTCACHE_DIR", pathlib.Path().home() / ".cltcache")
+    cltcache_path = pathlib.Path(os.environ.get(
+        "CLTCACHE_DIR", pathlib.Path().home() / ".cltcache"))
     cltcache_path.mkdir(parents=True, exist_ok=True)
     config = configparser.ConfigParser()
     config.read(cltcache_path / "cltcache.cfg")

--- a/src/cltcache/cltcache.py
+++ b/src/cltcache/cltcache.py
@@ -3,6 +3,7 @@
 A simple clang-tidy caching application. Prefix calls to clang-tidy to cache
 their results for faster static code analysis.
 """
+import configparser
 import gzip
 import hashlib
 import os
@@ -11,7 +12,6 @@ import re
 import subprocess
 import sys
 import time
-import configparser
 
 
 def save_to_file_raw(data, filename):


### PR DESCRIPTION
If the cache dir environment variable is set the `os.environ.get` returns a variable of type `str`. This results in an error on cache dir folder creation with `mkdir`.